### PR TITLE
Clean up convert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 .vscode
 temp
 _deps
+cmake-build-debug
+cmake-build-release

--- a/include/convert.hpp
+++ b/include/convert.hpp
@@ -1,6 +1,6 @@
 #include <vector>
 
-struct Waypoint{
+struct Waypoint {
     double x;
     double y;
     double z;
@@ -12,7 +12,7 @@ struct Waypoint{
     double tolerance;
 };
 
-struct GPSCoordinates{
+struct GPSCoordinates {
 
     double latitude;
     double longitude;
@@ -22,19 +22,23 @@ struct GPSCoordinates{
 
 class Convert {
 public:
-    static Convert convert_gps_to_waypoint(std::vector<GPSCoordinates>);
+    static Convert convert_gps_to_waypoint(const std::vector<GPSCoordinates>&);
+
     std::vector<Waypoint> get_waypoints();
+
     double get_x(double);
+
     double get_y(double);
+
     double get_yaw(double);
 
 private:
 
     Convert() = default;
 
-    double origin_x_, x_;
-    double origin_y_, y_;
-    double yaw_;
+    double origin_x_{}, x_{};
+    double origin_y_{}, y_{};
+    double yaw_{};
 
     // constant??
     double z_ = 0;

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1,28 +1,30 @@
 #include "../include/convert.hpp"
 #include <vector>
-#include <cmath>
+#include <numbers>
 
-Convert Convert::convert_gps_to_waypoint(std::vector<GPSCoordinates> gps_coordinates_list) {
-    Convert obj;
+Convert Convert::convert_gps_to_waypoint(const std::vector<GPSCoordinates>& gps_coordinates_list) {
+    Convert converter;
 
-    Waypoint temp_waypoint;
+    Waypoint temp_waypoint{};
 
     if (!gps_coordinates_list.empty()) {
-        for (auto temp_gps: gps_coordinates_list) {
-            if (obj.waypoints.empty()) {
-                obj.origin_x_ = temp_gps.latitude;
-                obj.origin_y_ = temp_gps.longitude;
-                obj.yaw_ = obj.get_yaw(temp_gps.orientation);
-                temp_waypoint = {0, 0, obj.z_, obj.roll_, obj.pitch_, obj.yaw_, obj.tolerance_};
-                obj.waypoints.push_back(temp_waypoint);
+        for (auto& temp_gps: gps_coordinates_list) {
+            // First gps point in vector is reference point
+            if (converter.waypoints.empty()) {
+                converter.origin_x_ = temp_gps.latitude;
+                converter.origin_y_ = temp_gps.longitude;
+                converter.yaw_ = converter.get_yaw(temp_gps.orientation);
+
+                temp_waypoint = {0, 0, converter.z_, converter.roll_, converter.pitch_, converter.yaw_, converter.tolerance_};
+                converter.waypoints.push_back(temp_waypoint);
             }
             else {
-                obj.x_ = obj.get_x(temp_gps.latitude);
-                obj.y_ = obj.get_y(temp_gps.longitude);
-                obj.yaw_ = obj.get_yaw(temp_gps.orientation);
+                converter.x_ = converter.get_x(temp_gps.latitude);
+                converter.y_ = converter.get_y(temp_gps.longitude);
+                converter.yaw_ = converter.get_yaw(temp_gps.orientation);
 
-                temp_waypoint = {obj.x_, obj.y_, obj.z_, obj.roll_, obj.pitch_, obj.yaw_, obj.tolerance_};
-                obj.waypoints.push_back(temp_waypoint);
+                temp_waypoint = {converter.x_, converter.y_, converter.z_, converter.roll_, converter.pitch_, converter.yaw_, converter.tolerance_};
+                converter.waypoints.push_back(temp_waypoint);
             }
         }
     }
@@ -37,7 +39,7 @@ Convert Convert::convert_gps_to_waypoint(std::vector<GPSCoordinates> gps_coordin
     phi = arctan(sqrt((x * x) + (y * y)) / z)
     */ 
 
-    return obj;
+    return converter;
 }
 
 std::vector<Waypoint> Convert::get_waypoints() {
@@ -52,5 +54,5 @@ double Convert::get_y(double gps_y) {
 }
 
 double Convert::get_yaw(double angle) {
-    return angle * M_PI / 180;
+    return angle * std::numbers::pi / 180;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,21 @@
 
 #include <iostream>
 #include "../include/readFile.hpp"
+#include "convert.hpp"
 //#include "fmt/core.h"
 
 
-int main(int argc, char* argv[]){
-        std::cout<<"hewwo";
+int main(int argc, char *argv[]) {
+    std::cout << "hewwo";
 
+    std::vector<GPSCoordinates> result = ReadFile::read("/home/hetricke/Documents/ISC/Testing/gps_test_read.txt");
 
-        std::vector<GPSCoordinates> result= ReadFile::read("/home/hetricke/Documents/ISC/Testing/gps_test_read.txt");
+    for (int i = 0; i < result.size(); i++) {
+        printf("%lf, %lf, %lf", result[i].longitude, result[i].latitude, result[i].orientation);
 
-        for (int i = 0; i<result.size(); i++){
-            printf("%lf, %lf, %lf", result[i].longitude, result[i].latitude, result[i].orientation);
+    }
 
-        }
+    auto converted = Convert::convert_gps_to_waypoint(result);
 
     return 0;
 }


### PR DESCRIPTION
Figured I'd clean up my work from earlier a bit. 

This does compile for me, so if it doesn't for you its likely an editor error.

FWIW, I don't think either the reader or converter needs to be a class. Because both can only be created by a factory, and neither are used for more than one action, there's not much to gain in using a class. If you want to keep the nice namespacing, just swap out the class keyword with namespace, like so:

```cpp
namespace converter {
    std::vector<Waypoint> convert_gps_to_waypoint(const std::vector<GPSCoordinates>& gps_coordinates_list);
}
```

That's just advice though, feel free to experiment with design for now.